### PR TITLE
Extended the check before executing the innerRef function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -174,7 +174,7 @@ export default class ParallaxScroll extends PureComponent {
   }
 
   _ref = (ref) => {
-    if (typeof this.props.innerRef === 'function') {
+    if (typeof this.props.innerRef === 'function' && ref && ref._component) {
       this.props.innerRef(ref._component);
     }
   };


### PR DESCRIPTION
This is a fix for this [issue](https://github.com/monterosalondon/react-native-parallax-scroll/issues/6)

The `this.props.innerRef` function will only be executed if the `ref` is actually available.