### PR TITLE
Allow for pointerEvents to be fired close the header

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -296,7 +296,7 @@ export default class ParallaxScroll extends Component {
       position: 'absolute',
       top: 0,
       width,
-      height,
+      height: this.isHeaderFixed ? this.props.headerHeight : height,
       zIndex: 1
     };
 
@@ -306,13 +306,17 @@ export default class ParallaxScroll extends Component {
           style={{
             position: 'absolute',
             width,
-            height,
+            height: this.isHeaderFixed ? this.props.headerHeight : height,
             opacity,
             transform: [{ translateY }]
           }}
           pointerEvents="box-none"
         >
-          {renderParallaxForeground({ width, height, animatedValue: this.scrollY })}
+          {renderParallaxForeground({
+            width,
+            height: this.isHeaderFixed ? this.props.headerHeight : height,
+            animatedValue: this.scrollY
+          })}
         </Animated.View>
       </View>
     );


### PR DESCRIPTION
I've experienced that none of my pointerEvents are firing close to my fixed header after the Parallax foreground had been collapsed. When using the inspector I found that the entire parallaxHeight was still assigned to the wrapperView of the foreground, causing it to render an invisible view on top of my scrollable component (in this case a Webview) which then blocks all click events in my webview under that area. 

Here is an image depicting the problem (the highlighted area is unclickable):
<img width="382" alt="blocking_view" src="https://user-images.githubusercontent.com/26295475/48634274-78d73900-e9c5-11e8-943b-88b2f5296152.png">

The PR includes minor changes to the height of the view to match the height of the collapsed header(headerHeight in props) when the parallax is collapsed after scrolling down.

