### PR TITLE
Fix forwarding `ref` 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -196,8 +196,8 @@ export default class ParallaxScroll extends Component {
   };
 
   _ref = ref => {
-    if (typeof this.props.innerRef === 'function' && ref && ref._component) {
-      this.props.innerRef(ref._component);
+    if (typeof this.props.innerRef === 'function' && ref) {
+      this.props.innerRef(ref._component || ref);
     }
   };
 


### PR DESCRIPTION
# Problem

Couldn't use `innerRef` object at least RN 60. For example, `ref.current.scrollTo({ y: 1000 })` does not work.

```tsx
const App = () => {
  const ref = React.useRef()
  const scroll = React.useCallback(() => {
    ref.current && ref.current.getNode().scrollTo({ y: 10000 })
  }, [ref.current])

  return (
    <>
      <Button onPress={scroll} title="let's scroll" />
      <ParallaxScroll ref={ref}><View style={{ height: 1500 }} /></ParallaxScroll>
    </>
  )
}
```

causes an error `ref.current.getNode is not a function`

# Changes

I didn't understand `ref._component`, but it should accept `ref` itself. so I've added forwarding `ref` if `ref._component` is not set.

# Related Issues

- https://github.com/monterosalondon/react-native-parallax-scroll/issues/6
- https://github.com/monterosalondon/react-native-parallax-scroll/pull/7